### PR TITLE
Use hmac.compare_digest instead of plain ==

### DIFF
--- a/simpleotp/otp.py
+++ b/simpleotp/otp.py
@@ -69,7 +69,7 @@ class OTP(object):
         hash_string = self.__generate_hash_string(otp, expiry)
         n_dig = self.__hmac(hash_string)
 
-        if dig == n_dig:
+        if hmac.compare_digest(dig, n_dig):
             return True
 
         return False


### PR DESCRIPTION
This is supposed to reduce the vulnerability to timing attacks

Ref: https://docs.python.org/3/library/hmac.html#hmac.HMAC.digest

Fixes #2